### PR TITLE
fix: correct Nixos installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,33 @@ and restores your window layout.
 
 ```nix
 {
-  inputs.nirinit = {
-    url = "github:amaanq/nirinit";
-    inputs.nixpkgs.follows = "nixpkgs";
-  };
+  # In Nix Flake
+  {
+    inputs.nirinit = {
+      url = "github:amaanq/nirinit";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
+    outputs = {nirinit, ...}@inputs:
+    {
+      nixosConfigurations.default = nixpkgs.lib.nixosSystem {
+        specialArgs = { inherit inputs; };
+        modules = [ nirinit.nixosModules.nirinit ];
+      };
+    };
+  }
+  
   # In your NixOS configuration:
-  imports = [ nirinit.nixosModules.nirinit ];
-
-  services.nirinit.enable = true;
+  {...}:
+  {
+    services.nirinit.enable = true;
+  }
 
   # In your Home Manager configuration:
-  imports = [ nirinit.homeModules.nirinit ];
-
-  services.nirinit.settings.skip.apps = [ "discord" "firefox" ];
+  {...}:
+  {
+    services.nirinit.settings.skip.apps = [ "discord" "firefox" ];
+  }
 }
 ```
 


### PR DESCRIPTION
Putting ```nirinit.nixosModules.nirinit``` or ```nirinit.homeModules.nirinit``` in imports causes infinite recursion and results in an error while building.

Also, in home manager I get "The option 'services.nirinit' does not exist.", I've tried multiple methods to fix this, and couldn't find a way. It may have to be fixed within the flake itself, but I don't have much knowledge with writing flakes, so I personally don't know how to fix it.