### PR TITLE
docs: remove outdated section on `homeModules`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,7 @@ Import the NixOS module and configure:
   };
 }
 ```
-
-Import the Home Manager module to generate the config file:
-
-```nix
-# home.nix
-{ inputs, ... }:
-{
-  imports = [ inputs.nirinit.homeModules.nirinit ];
-}
-```
-
-Note: Settings are defined in the NixOS module. The Home Manager module reads
-from `osConfig` and generates `$XDG_CONFIG_HOME/nirinit/config.toml`.
+The config file will live in the nix store and its path is specified using the `--config` flag in the systemd service. 
 
 ### Manual
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Import the NixOS module and configure:
   };
 }
 ```
+
 The config file will live in the nix store and its path is specified using the `--config` flag in the systemd service. 
 
 ### Manual


### PR DESCRIPTION
The attrset homeModules was removed in 76d532ea38f08f908ec5972216fbb88ed42f3da3, with the config file now just living in the nix store and its path being specified by the `--config` flag in the systemd service. This pull request just reflects this reality in the README.